### PR TITLE
Add check for already-initialized devices

### DIFF
--- a/tfaip/device/device_config.py
+++ b/tfaip/device/device_config.py
@@ -98,7 +98,10 @@ class DeviceConfig:
                 f"GPU device not available. Number of devices detected: {len(physical_gpu_devices)}"
             ) from e
 
+        try:
         tf.config.experimental.set_visible_devices(physical_gpu_devices, "GPU")
+        except RuntimeError:
+            logging.warn("Couldn't set visible devices! Are they already initialized?")
         for physical_gpu_device in physical_gpu_devices:
             tf.config.experimental.set_memory_growth(physical_gpu_device, self._params.gpu_memory is None)
             if self._params.gpu_memory is not None:

--- a/tfaip/device/device_config.py
+++ b/tfaip/device/device_config.py
@@ -99,7 +99,7 @@ class DeviceConfig:
             ) from e
 
         try:
-        tf.config.experimental.set_visible_devices(physical_gpu_devices, "GPU")
+            tf.config.experimental.set_visible_devices(physical_gpu_devices, "GPU")
         except RuntimeError:
             logging.warn("Couldn't set visible devices! Are they already initialized?")
         for physical_gpu_device in physical_gpu_devices:


### PR DESCRIPTION
If you're using tfaip in an environment in which many different jobs call TensorFlow from various contexts, (like [ours](https://github.com/DDMAL/Rodan)), `set_visible_devices` can fail with this error:
```
RuntimeError: Visible devices cannot be modified after being initialized
```
With this PR, a warning is logged, but the code continues as normal.

If you have another suggestion on how this multiple instantiation problem could be solved, I'm open to suggestion! FYI, we are using [Calamari](https://github.com/Calamari-OCR/calamari) to perform OCR, which calls `tfaip`.